### PR TITLE
enhancement: extended .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,122 @@
-__pycache__
-notebooks/.ipynb_checkpoints
-notebooks/data
+# ignore folders anywhere in the repo
+**/data
+**/.ipynb_checkpoints
+**/__pycache__
+**/.idea
+
+# ignore specific folders
+write_results/
+figures/
+dataframes/
+write_results/
+
+# ignore files anywhere in the repo
+paths.py
+
+# generic python stuff to ignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.Rhistory
+.pybiomart.sqlite
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/


### PR DESCRIPTION
this extends the gitignore. When you create a new repo on github, it asks you whether you want to initialise with a gitignore. If you chose that option, you can select a standard gitignore for python that includes many cases you want to ignore by default. Quite handy.